### PR TITLE
Add common var-generating functions to maketable1 branch

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -4,7 +4,7 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 permissions:
-  contents: read/write
+  contents: write
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,11 +3,11 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+permissions:
+  contents: read/write
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/src/DellReplicate.jl
+++ b/src/DellReplicate.jl
@@ -178,21 +178,28 @@ module DellReplicate
     
     end
 
+    function keep_20yrs_gdp(df::DataFrames.DataFrame)
+        
+        df[!, :nonmissing] .= ifelse.(ismissing.(df.g_lngdpwdi), 0, 1)
+        transform!(groupby(df, :fips60_06), :nonmissing => sum∘skipmissing)
+        filter!(:nonmissing_sum_skipmissing => >=(20), df)
+        return df
+
+    end
+
     """
-        gen_vars_fig2(df::DataFrames.DataFrame)
-    Generates all the variables necessary for figure 2.
+        gen_lag_vars(df::DataFrames.DataFrame)
+    Generates all the variables necessary for figure 2 and others.
     """
-    function gen_lags_fig2(df::DataFrames.DataFrame)
+    function gen_lag_vars(df::DataFrames.DataFrame)
         
         lag_df = df[:, [:year, :fips60_06, :wtem, :wpre, :wtem50, :wpre50]]
 
         for var in [ "wtem", "wpre" ]
-            df[!, "$(var)Xlnrgdpl_t0"] .= df[:, var] .* df[:, :lnrgdpl_t0]
-            lag_df[!, "$(var)Xlnrgdpl_t0"] = df[:, "$(var)Xlnrgdpl_t0"]
+            lag_df[!, "$(var)Xlnrgdpl_t0"] .= df[:, var] .* df[:, :lnrgdpl_t0]
 
             for bin_var in [ "initagshare95xtile1", "initagshare95xtile2", "initgdpxtile1", "initgdpxtile2", "initwtem50xtile1", "initwtem50xtile2"]
-                df[!, "$(var)_$(bin_var)"] .= df[:, var] .* df[:, bin_var]
-                lag_df[!, "$(var)_$(bin_var)"] = df[:, "$(var)_$(bin_var)"]
+                lag_df[!, "$(var)_$(bin_var)"] .= df[:, var] .* df[:, bin_var]
             end
 
         end
@@ -201,60 +208,43 @@ module DellReplicate
 
         for var in vars_to_lag
             transform!(groupby(lag_df, :fips60_06), var => lag => "L1$(var)") 
+            lag_df[!, Symbol(:fd,var)] .= lag_df[:, var] .- lag_df[:, "L1$(var)"]
             for n_lag in 2:10
                 transform!(groupby(lag_df, :fips60_06), "L$(n_lag-1)$(var)" => lag => "L$(n_lag)$(var)")
             end
         end
         #we should be at line 137 in the do file here !
+
         return outerjoin(df, lag_df, on=[:fips60_06, :year], makeunique=true)
 
     end
 
-    function gen_yearvars_fig2(df::DataFrames.DataFrame, years::Vector{Int64})
+    function gen_year_vars(df::DataFrames.DataFrame)
+        
+        numyears = maximum([ size(subfd)[1] for subfd in groupby(df, :fips60_06)] ) - 1
+        unique_years = [year for year in range(1,numyears+1)]
         
         region_vars = ["_MENA", "_SSAF", "_LAC", "_WEOFF", "_EECA", "_SEAS"]
         temp_df = df[:, [Symbol(col) for col in names(df) if (col in region_vars) | (col in ["initgdpxtile1", "year", "fips60_06"]) | (col[1:2] == "yr")]]
 
-        for year in years
-            for region in region_vars
-                temp_df[!, Symbol(:RY, year, "X", region)] .= temp_df[:, Symbol(:yr_,year)] .* temp_df[:, region]
+        #dummies: 1 for each year
+        transform!(groupby(temp_df, [:fips60_06, :year]), @. :year => ByRow(isequal(1949+unique_years)) .=> Symbol(:yr_, unique_years))
+
+        for year in unique_years
+            if year != 54
+                for region in region_vars
+                    temp_df[!, Symbol(:RY, year, "X", region)] .= temp_df[:, Symbol(:yr_,year)] .* temp_df[:, region]
+                end
+                temp_df[!, Symbol(:RY, "PX", year)] .= temp_df[:, Symbol(:yr_,year)] .* temp_df.initgdpxtile1
             end
-            temp_df[!, Symbol(:RY, "PX", year)] .= temp_df[:, Symbol(:yr_,year)] .* temp_df.initgdpxtile1
         end
-        println(temp_df[53:54, [:RY1X_MENA, :yr_54, :RY53X_MENA, :RY54X_MENA,:year, :fips60_06]], size(temp_df))
+
+        return outerjoin(df, temp_df, on=[:fips60_06, :year], makeunique=true)
 
     end
 
-    function figure2_visualise(df_name::String)
+    function gen_xtile_vars(climate_panel::DataFrames.DataFrame)
 
-        climate_panel = read_csv(df_name)
-        filter!(:year => <=(2003), climate_panel)
-
-        sort!(climate_panel, [:fips60_06, :year])
-        
-        # Direct broadcast is faster
-        climate_panel[!, :lngdpwdi] .= log.(climate_panel.gdpLCU)
-        climate_panel[!, :lngdppwt] .= log.(climate_panel.rgdpl)
-        growth_var!(climate_panel, :lngdpwdi)
-        growth_var!(climate_panel, :lngdppwt)
-
-        climate_panel[!, :lnag] .= log.(climate_panel.gdpWDIGDPAGR)
-        climate_panel[!, :lnind] .= log.(climate_panel.gdpWDIGDPIND)
-        climate_panel[!, :lninvest] .= log.( ( climate_panel.rgdpl .* climate_panel.ki ) ./ 100)
-
-       # growth Lags for lnag lnind lngdpwdi lninvest 
-        transform!(groupby(climate_panel, :fips60_06), [ :lnag, :lnind, :lngdpwdi, :lninvest ] .=> lag)
-
-        for var in [ :ag, :ind, :gdpwdi, :invest ]
-            climate_panel[!, "g$(var)"] .= ( climate_panel[:,"ln$var"] .- climate_panel[:,"ln$(var)_lag"] ) .* 100
-        end
-
-        # Drop if less than 20 years of GDP values
-        climate_panel[!, :nonmissing] .= ifelse.(ismissing.(climate_panel.g_lngdpwdi), 0, 1)
-        transform!(groupby(climate_panel, :fips60_06), :nonmissing => sum∘skipmissing)
-        climate_panel = climate_panel[(climate_panel[!, :nonmissing_sum_skipmissing] .>= 20), :]       
-
-        # Create 3 copies to be merged
         temp1 = copy(climate_panel)
         filter!(:lnrgdpl_t0 => (x -> !ismissing.(x)), temp1)
         transform!(groupby(temp1, :fips60_06), eachindex => :countrows)
@@ -302,16 +292,43 @@ module DellReplicate
         merged_3[!, :initagshare95xtile1] .= ifelse.(merged_3.initagshare1995 .== 1, 1, ifelse.(merged_3.initagshare1995 .== 2, 0, missing))
         merged_3[!, :initagshare95xtile2] .= ifelse.(merged_3.initagshare1995 .== 2, 1, ifelse.(merged_3.initagshare1995 .== 1, 0, missing))
         println(merged_3[1:200, [:fips60_06, :initagshare95xtile1, :initagshare95xtile2]])
-        climate_panel = merged_3
+         
+        return merged_3
+    end
 
-        climate_panel = gen_lags_fig2(climate_panel)
-        numyears = maximum([ size(subfd)[1] for subfd in groupby(climate_panel, :fips60_06)] ) - 1
-        unique_years = [year for year in range(1,numyears+1)]
-        println(unique_years)
-        transform!(groupby(climate_panel, [:fips60_06, :year]), @. :year => ByRow(isequal(1949+unique_years)) .=> Symbol(:yr_, unique_years))
-        gen_yearvars_fig2(climate_panel, unique_years)
-        #numyears = size()[1] - 1
-        #println(climate_panel[1:60, [:fips60_06, :year]])
+    function figure2_visualise(df_name::String)
+
+        climate_panel = read_csv(df_name)
+        filter!(:year => <=(2003), climate_panel)
+
+        sort!(climate_panel, [:fips60_06, :year])
+        
+        # Direct broadcast is faster
+        climate_panel[!, :lngdpwdi] .= log.(climate_panel.gdpLCU)
+        climate_panel[!, :lngdppwt] .= log.(climate_panel.rgdpl)
+        growth_var!(climate_panel, :lngdpwdi)
+        growth_var!(climate_panel, :lngdppwt)
+
+        climate_panel[!, :lnag] .= log.(climate_panel.gdpWDIGDPAGR)
+        climate_panel[!, :lnind] .= log.(climate_panel.gdpWDIGDPIND)
+        climate_panel[!, :lninvest] .= log.( ( climate_panel.rgdpl .* climate_panel.ki ) ./ 100)
+
+       # growth Lags for lnag lnind lngdpwdi lninvest 
+        transform!(groupby(climate_panel, :fips60_06), [ :lnag, :lnind, :lngdpwdi, :lninvest ] .=> lag)
+
+        for var in [ :ag, :ind, :gdpwdi, :invest ]
+            climate_panel[!, "g$(var)"] .= ( climate_panel[:,"ln$var"] .- climate_panel[:,"ln$(var)_lag"] ) .* 100
+        end
+
+        # Drop if less than 20 years of GDP values
+        climate_panel = keep_20yrs_gdp(climate_panel)
+        #climate_panel = climate_panel[(climate_panel[!, :nonmissing_sum_skipmissing] .>= 20), :]       
+        climate_panel = gen_xtile_vars(climate_panel)
+        climate_panel = gen_lag_vars(climate_panel)
+        climate_panel = gen_year_vars(climate_panel)
+        println(size(climate_panel))
+        #a few duplicates are created here.
+
         #CODES: 999 IF MISSING BIN
 
     end
@@ -319,9 +336,9 @@ module DellReplicate
     #figure2_visualise("climate_panel_csv.csv")
 
     """
-        function make_table_1(raw_df_name::String)
+        make_table_1(raw_df_name::String)
     
-        Create summary statistics of the Data.
+    Create summary statistics of the Data.
 
     """
     function make_table1(raw_df_name::String)


### PR DESCRIPTION
This merge adds the functions `gen_lag_vars`, `gen_year_vars` and `gen_xtile_vars` to the module. These functions mostly create variables, and are used in more than 1 do-file of the whole paper. As of now, one (small) issue is known: one of the outerjoins duplicates a few of the variables (11 of them), thus the stata dataset has 686 vars whilst the julia one has 697. These are currently not dropped.